### PR TITLE
Updates rake

### DIFF
--- a/codestats-metrics-reporter.gemspec
+++ b/codestats-metrics-reporter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rubocop', '~> 0.42'
-  spec.add_dependency 'rake', '~> 0.8'
+  spec.add_dependency 'rake', '~> 0.8.7'
   spec.add_dependency 'httparty', '~> 0.13'
   spec.add_dependency 's3_uploader', '~> 0.2'
   spec.add_dependency 'oga', '~> 1.3'


### PR DESCRIPTION
```
Bundler could not find compatible versions for gem "rake":
  In snapshot (Gemfile.lock):
    rake (= 11.2.2)

  In Gemfile:
    codestats-metrics-reporter was resolved to 0.1.1, which depends on
      rake (~> 0.8)

    factory_girl_rails was resolved to 4.7.0, which depends on
      railties (>= 3.0.0) was resolved to 5.0.0.1, which depends on
        rake (>= 0.8.7)

    scss_lint was resolved to 0.49.0, which depends on
      rake (< 12, >= 0.9)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```
